### PR TITLE
Provide alternative/more informative operation names for spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,172 @@ Cluster cluster = new TracingCluster(builder, tracer);
 
 ```
 
+## Span Names
+By default, spans for executed queries will be created with the name `execute`.
+To use a different name for the query spans, you can create a custom name provider by implementing
+the QuerySpanNameProvider interface.
+
+### QuerySpanNameProvider interface
+
+```java
+public interface QuerySpanNameProvider {
+  public interface Builder {
+    QuerySpanNameProvider build();
+  }
+
+  /**
+   * Given a Cassandra query, return a name for the span
+   * @param query Cassandra query
+   * @return Name for query's span
+   */
+  String querySpanName(String query);
+
+}
+```
+
+### CustomStringSpanName
+Returns a predefined string for every span. Defaults to `execute` on null or "" argument to build()
+```java
+import io.opentracing.contrib.cassandra.QuerySpanNameProvider.CustomStringSpanName;
+import io.opentracing.contrib.cassandra.QuerySpanNameProvider.QuerySpanNameProvider;
+...
+
+// Initialize with custom string
+QuerySpanNameProvider querySpanNameProvider = CustomStringSpanName.newBuilder().build("CUSTOM_NAME");
+
+
+// Instantiate Tracing Cluster with QuerySpanNameProvider as an argument
+Tracer tracer = ...
+Cluster.Builder builder = ...
+Cluster cluster = new TracingCluster(builder, tracer, querySpanNameProvider);
+
+Session session = cluster.newSession();
+
+// Execute query
+session.execute("SELECT * FROM example.table WHERE field = ?", "test");
+// Span is created with span name 
+// "CUSTOM_NAME"
+
+```
+
+### FullQuerySpanName
+Returns the full query as the span name.
+```java
+import io.opentracing.contrib.cassandra.QuerySpanNameProvider.FullQuerySpanName;
+import io.opentracing.contrib.cassandra.QuerySpanNameProvider.QuerySpanNameProvider;
+...
+
+// Initialize
+QuerySpanNameProvider querySpanNameProvider = FullQuerySpanName.newBuilder().build();
+
+
+// Instantiate Tracing Cluster with QuerySpanNameProvider as an argument
+Tracer tracer = ...
+Cluster.Builder builder = ...
+Cluster cluster = new TracingCluster(builder, tracer, querySpanNameProvider);
+
+Session session = cluster.newSession();
+
+// Execute query
+session.execute("SELECT * FROM example.table WHERE field = ?", "test");
+
+// Span is created with the full query as the span name,
+// "SELECT * FROM example.table WHERE field = ?;"
+
+// Span name will be parameterized if the original given query is parameterized.
+
+```
+
+### PrefixedFullQuerySpanName
+Returns the full query as the span name, with a custom string prefix. Defaults to `Cassandra` on null or "" argument to build().
+```java
+import io.opentracing.contrib.cassandra.QuerySpanNameProvider.PrefixedFullQuerySpanName;
+import io.opentracing.contrib.cassandra.QuerySpanNameProvider.QuerySpanNameProvider;
+...
+
+// Initialize with custom prefix string
+QuerySpanNameProvider querySpanNameProvider = PrefixedFullQuerySpanName.newBuilder().build("CUSTOM_PREFIX");
+
+
+// Instantiate Tracing Cluster with QuerySpanNameProvider as an argument
+Tracer tracer = ...
+Cluster.Builder builder = ...
+Cluster cluster = new TracingCluster(builder, tracer, querySpanNameProvider);
+
+
+Session session = cluster.newSession();
+
+// Execute query
+session.execute("SELECT * FROM example.table WHERE field = ?", "test");
+
+// Span is created with the full query as the span name, prefixed with the custom prefix, 
+// "CUSTOM_PREFIX: SELECT * FROM example.table WHERE field = ?;"
+
+// Span name will be parameterized if the original given query is parameterized.
+
+```
+
+### QueryMethodTableSpanName
+Returns formatted string `Cassandra.[METHOD] - [TARGET_ENTITY]` where [METHOD] is the Cassandra Method and [TARGET_ENTITY] is the
+entity that the method is acting on (view, keyspace, table, index). 
+
+For methods that require no target entity, returns `Cassandra.[METHOD]`.
+
+
+If a method does require a target entity, but none is found, returns `Cassandra.[METHOD] - N/A`.
+
+
+The supported Cassandra methods are:
+- SELECT
+- INSERT
+- UPDATE
+- DELETE
+- BATCH
+- USE
+- CREATE MATERIALIZED VIEW
+- ALTER MATERIALIZED VIEW
+- DROP MATERIALIZED VIEW
+- CREATE KEYSPACE
+- ALTER KEYSPACE
+- DROP KEYSPACE
+- CREATE TABLE
+- ALTER TABLE
+- DROP TABLE
+- TRUNCATE
+- CREATE INDEX
+- DROP INDEX
+```java
+import io.opentracing.contrib.cassandra.QuerySpanNameProvider.QueryMethodTableSpanName;
+import io.opentracing.contrib.cassandra.QuerySpanNameProvider.QuerySpanNameProvider;
+...
+
+// Initialize
+QuerySpanNameProvider querySpanNameProvider = QueryMethodTableSpanName.newBuilder().build();
+
+
+// Instantiate Tracing Cluster with QuerySpanNameProvider as an argument
+Tracer tracer = ...
+Cluster.Builder builder = ...
+Cluster cluster = new TracingCluster(builder, tracer, querySpanNameProvider);
+
+Session session = cluster.newSession();
+
+// Execute query
+session.execute("SELECT * FROM example.table WHERE field = ?", "test");
+
+// Span is created with the method and target entity in the name,
+// "Cassandra.SELECT - example.table"
+
+// Provider has support for additional qualifiers IF EXISTS and IF NOT EXISTS
+session.execute("CREATE TABLE example.table;");
+session.execute("CREATE TABLE IF NOT EXISTS example.table;")
+
+// Two spans are created with the same name,
+// "Cassandra.CREATE_TABLE - example.table"
+
+```
+
+
 [ci-img]: https://travis-ci.org/opentracing-contrib/java-cassandra-driver.svg?branch=master
 [ci]: https://travis-ci.org/opentracing-contrib/java-cassandra-driver
 [cov-img]: https://coveralls.io/repos/github/opentracing-contrib/java-cassandra-driver/badge.svg?branch=master

--- a/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/CustomStringSpanName.java
+++ b/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/CustomStringSpanName.java
@@ -21,7 +21,7 @@ public class CustomStringSpanName implements QuerySpanNameProvider {
 
   private String customString;
 
-  static class Builder implements QuerySpanNameProvider.Builder {
+  public static class Builder implements QuerySpanNameProvider.Builder {
     // Defaults to "execute"
     @Override
     public QuerySpanNameProvider build() { return new io.opentracing.contrib.cassandra.QuerySpanNameProvider.CustomStringSpanName("execute");}

--- a/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/CustomStringSpanName.java
+++ b/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/CustomStringSpanName.java
@@ -1,0 +1,30 @@
+package io.opentracing.contrib.cassandra.QuerySpanNameProvider;
+
+public class CustomStringSpanName implements QuerySpanNameProvider {
+
+  private String customString;
+
+  static class Builder implements QuerySpanNameProvider.Builder {
+    // Defaults to "execute"
+    @Override
+    public QuerySpanNameProvider build() { return new io.opentracing.contrib.cassandra.QuerySpanNameProvider.CustomStringSpanName("execute");}
+
+    // Provide customString
+    public QuerySpanNameProvider build(String customString) { return new io.opentracing.contrib.cassandra.QuerySpanNameProvider.CustomStringSpanName(customString);}
+  }
+
+  CustomStringSpanName(String customString) {
+    if(customString == null) {
+      this.customString = "execute";
+    } else {
+      this.customString = customString;
+    }
+  }
+
+  @Override
+  public String querySpanName(String query) {
+    return customString;
+  }
+
+  public static Builder newBuilder() { return new Builder();}
+}

--- a/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/CustomStringSpanName.java
+++ b/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/CustomStringSpanName.java
@@ -24,10 +24,10 @@ public class CustomStringSpanName implements QuerySpanNameProvider {
   public static class Builder implements QuerySpanNameProvider.Builder {
     // Defaults to "execute"
     @Override
-    public QuerySpanNameProvider build() { return new io.opentracing.contrib.cassandra.QuerySpanNameProvider.CustomStringSpanName("execute");}
+    public QuerySpanNameProvider build() { return new CustomStringSpanName("execute");}
 
     // Provide customString
-    public QuerySpanNameProvider build(String customString) { return new io.opentracing.contrib.cassandra.QuerySpanNameProvider.CustomStringSpanName(customString);}
+    public QuerySpanNameProvider build(String customString) { return new CustomStringSpanName(customString);}
   }
 
   CustomStringSpanName(String customString) {

--- a/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/CustomStringSpanName.java
+++ b/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/CustomStringSpanName.java
@@ -1,5 +1,22 @@
+/*
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.cassandra.QuerySpanNameProvider;
 
+/**
+ * @author Jordan J Lopez
+ *  Returns a predifined string for every span
+ */
 public class CustomStringSpanName implements QuerySpanNameProvider {
 
   private String customString;

--- a/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/FullQuerySpanName.java
+++ b/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/FullQuerySpanName.java
@@ -21,7 +21,7 @@ public class FullQuerySpanName implements QuerySpanNameProvider {
 
   public static class Builder implements QuerySpanNameProvider.Builder {
     @Override
-    public QuerySpanNameProvider build() { return new io.opentracing.contrib.cassandra.QuerySpanNameProvider.FullQuerySpanName();}
+    public QuerySpanNameProvider build() { return new FullQuerySpanName();}
 
   }
 

--- a/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/FullQuerySpanName.java
+++ b/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/FullQuerySpanName.java
@@ -19,7 +19,7 @@ package io.opentracing.contrib.cassandra.QuerySpanNameProvider;
  */
 public class FullQuerySpanName implements QuerySpanNameProvider {
 
-  static class Builder implements QuerySpanNameProvider.Builder {
+  public static class Builder implements QuerySpanNameProvider.Builder {
     @Override
     public QuerySpanNameProvider build() { return new io.opentracing.contrib.cassandra.QuerySpanNameProvider.FullQuerySpanName();}
 

--- a/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/FullQuerySpanName.java
+++ b/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/FullQuerySpanName.java
@@ -1,5 +1,22 @@
+/*
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.cassandra.QuerySpanNameProvider;
 
+/**
+ * @author Jordan J Lopez
+ *  Returns the full query as the span name
+ */
 public class FullQuerySpanName implements QuerySpanNameProvider {
 
   static class Builder implements QuerySpanNameProvider.Builder {

--- a/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/FullQuerySpanName.java
+++ b/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/FullQuerySpanName.java
@@ -1,0 +1,25 @@
+package io.opentracing.contrib.cassandra.QuerySpanNameProvider;
+
+public class FullQuerySpanName implements QuerySpanNameProvider {
+
+  static class Builder implements QuerySpanNameProvider.Builder {
+    @Override
+    public QuerySpanNameProvider build() { return new io.opentracing.contrib.cassandra.QuerySpanNameProvider.FullQuerySpanName();}
+
+  }
+
+  FullQuerySpanName() {
+
+  }
+
+  @Override
+  public String querySpanName(String query) {
+    if(query == null || query.equals("")) {
+      return "N/A";
+    } else {
+      return query;
+    }
+  }
+
+  public static Builder newBuilder() { return new Builder();}
+}

--- a/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/PrefixedFullQuerySpanName.java
+++ b/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/PrefixedFullQuerySpanName.java
@@ -22,9 +22,9 @@ public class PrefixedFullQuerySpanName implements QuerySpanNameProvider {
 
   public static class Builder implements QuerySpanNameProvider.Builder {
     @Override
-    public QuerySpanNameProvider build() { return new io.opentracing.contrib.cassandra.QuerySpanNameProvider.PrefixedFullQuerySpanName("Cassandra");}
+    public QuerySpanNameProvider build() { return new PrefixedFullQuerySpanName("Cassandra");}
 
-    public QuerySpanNameProvider build(String prefix) {return new io.opentracing.contrib.cassandra.QuerySpanNameProvider.PrefixedFullQuerySpanName(prefix);}
+    public QuerySpanNameProvider build(String prefix) {return new PrefixedFullQuerySpanName(prefix);}
   }
 
   PrefixedFullQuerySpanName(String prefix) {

--- a/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/PrefixedFullQuerySpanName.java
+++ b/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/PrefixedFullQuerySpanName.java
@@ -1,0 +1,31 @@
+package io.opentracing.contrib.cassandra.QuerySpanNameProvider;
+
+public class PrefixedFullQuerySpanName implements QuerySpanNameProvider {
+  private String prefix;
+
+  static class Builder implements QuerySpanNameProvider.Builder {
+    @Override
+    public QuerySpanNameProvider build() { return new io.opentracing.contrib.cassandra.QuerySpanNameProvider.PrefixedFullQuerySpanName("Cassandra");}
+
+    public QuerySpanNameProvider build(String prefix) {return new io.opentracing.contrib.cassandra.QuerySpanNameProvider.PrefixedFullQuerySpanName(prefix);}
+  }
+
+  PrefixedFullQuerySpanName(String prefix) {
+    if(prefix == null || prefix.equals("")) {
+      this.prefix = "";
+    } else {
+      this.prefix = prefix + ": ";
+    }
+  }
+
+  @Override
+  public String querySpanName(String query) {
+    if(query == null || query.equals("")) {
+      return this.prefix + "N/A";
+    } else {
+      return this.prefix + query;
+    }
+  }
+
+  public static Builder newBuilder() { return new Builder();}
+}

--- a/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/PrefixedFullQuerySpanName.java
+++ b/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/PrefixedFullQuerySpanName.java
@@ -20,7 +20,7 @@ package io.opentracing.contrib.cassandra.QuerySpanNameProvider;
 public class PrefixedFullQuerySpanName implements QuerySpanNameProvider {
   private String prefix;
 
-  static class Builder implements QuerySpanNameProvider.Builder {
+  public static class Builder implements QuerySpanNameProvider.Builder {
     @Override
     public QuerySpanNameProvider build() { return new io.opentracing.contrib.cassandra.QuerySpanNameProvider.PrefixedFullQuerySpanName("Cassandra");}
 

--- a/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/PrefixedFullQuerySpanName.java
+++ b/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/PrefixedFullQuerySpanName.java
@@ -1,5 +1,22 @@
+/*
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.cassandra.QuerySpanNameProvider;
 
+/**
+ * @author Jordan J Lopez
+ *  Returns a custom prefix and the full query as the span name
+ */
 public class PrefixedFullQuerySpanName implements QuerySpanNameProvider {
   private String prefix;
 

--- a/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/QueryMethodTableSpanName.java
+++ b/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/QueryMethodTableSpanName.java
@@ -1,0 +1,160 @@
+package io.opentracing.contrib.cassandra.QuerySpanNameProvider;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class QueryMethodTableSpanName implements QuerySpanNameProvider {
+
+  // Pulled from http://cassandra.apache.org/doc/latest/cql/
+  enum ManipulationMethod
+  {
+    SELECT, INSERT, UPDATE, DELETE, BATCH, NOT_FOUND
+  }
+
+  private final String[] CASSANDRA_MANIPULATION_METHODS = {
+      "BATCH",
+      "SELECT",
+      "INSERT",
+      "UPDATE",
+      "DELETE"
+  };
+
+  // Pulled from http://cassandra.apache.org/doc/latest/cql/
+  enum DefinitionMethod
+  {
+    CREATE_KEYSPACE, USE, ALTER_KEYSPACE, DROP_KEYSPACE, CREATE_TABLE,
+    ALTER_TABLE, DROP_TABLE, TRUNCATE, CREATE_INDEX, DROP_INDEX,
+    CREATE_MATERIALIZED_VIEW, ALTER_MATERIALIZED_VIEW,
+    DROP_MATERIALIZED_VIEW, NOT_FOUND
+  }
+
+  private final String[] CASSANDRA_DEFINITION_METHODS = {
+      "CREATE KEYSPACE",
+      "USE",
+      "ALTER KEYSPACE",
+      "DROP KEYSPACE",
+      "CREATE TABLE",
+      "ALTER TABLE",
+      "DROP TABLE",
+      "TRUNCATE",
+      "CREATE INDEX",
+      "DROP INDEX",
+      "CREATE MATERIALIZED VIEW",
+      "ALTER MATERIALIZED VIEW",
+      "DROP MATERIALIZED VIEW"
+  };
+
+  static class Builder implements QuerySpanNameProvider.Builder {
+    @Override
+    public QuerySpanNameProvider build() { return new io.opentracing.contrib.cassandra.QuerySpanNameProvider.QueryMethodTableSpanName();}
+
+  }
+
+  QueryMethodTableSpanName() {
+  }
+
+  @Override
+  public String querySpanName(String query) {
+    // Short Circuit
+    if(query == null || query.equals("")) {
+      return "Cassandra";
+    }
+
+    String queryMethod;
+    String queryTable = "N/A";
+    // First check to see if query is a manipulation method
+    ManipulationMethod manipulationMethod = getManipulationMethod(query);
+    queryMethod = manipulationMethod.toString();
+    if(!manipulationMethod.equals(ManipulationMethod.NOT_FOUND)) {
+      switch (manipulationMethod) {
+        case SELECT:    // SELECT ... FROM X ...
+        case DELETE:    // DELETE ... FROM X ...
+          queryTable = findTableAfter(query, "FROM");
+          break;
+        case INSERT:    // INSERT ... INTO X ...
+          queryTable = findTableAfter(query, "INTO");
+          break;
+        case UPDATE:    // UPDATE X ...
+          queryTable = findTableAfter(query, "UPDATE");
+          break;
+        case BATCH:     // BATCH
+          return String.format("Cassandra.%s",queryMethod);
+        default:
+          return "Cassandra";
+      }
+      return String.format("Cassandra.%s - %s", manipulationMethod.toString(), queryTable);
+    }
+
+    // If reached this point, manipulationMethod is set to  NOT_FOUND
+    DefinitionMethod definitionMethod = getDefininitionMethod(query);
+    queryMethod = definitionMethod.toString().replace("_", " ");
+    if(!definitionMethod.equals(DefinitionMethod.NOT_FOUND)) {
+      switch(definitionMethod) {
+        case USE:             // USE X ...
+        case ALTER_KEYSPACE:      // ALTER KEYSPACE X ...
+        case ALTER_MATERIALIZED_VIEW:   // ALTER MATERIALIZED VIEW X ...
+        case ALTER_TABLE:         // ALTER TABLE X ...
+          queryTable = findTableAfter(query, queryMethod);
+          break;
+        case DROP_INDEX:        // DROP INDEX [IF EXISTS] X ...
+        case DROP_KEYSPACE:       // DROP KEYSPACE [IF EXISTS] X ...
+        case DROP_MATERIALIZED_VIEW:  // DROP MATERIALIZED VIEW [IF EXISTS] X ...
+        case DROP_TABLE:        // DROP TABLE [IF EXISTS] X ...
+          queryTable = findTableAfter(query, queryMethod + " IF EXISTS");
+          if(queryTable.equals("N/A")) {queryTable = findTableAfter(query, queryMethod);}
+          break;
+        case CREATE_INDEX:        // CREATE INDEX [IF NOT EXISTS] X ...
+        case CREATE_KEYSPACE:       // CREATE KEYSPACE [IF NOT EXISTS] X ...
+        case CREATE_MATERIALIZED_VIEW:  // CREATE MATERIALIZED VIEW [IF NOT EXISTS] X ...
+        case CREATE_TABLE:        // CREATE TABLE [IF NOT EXISTS] X ...
+          queryTable = findTableAfter(query, queryMethod + " IF NOT EXISTS");
+          if(queryTable.equals("N/A")) {queryTable = findTableAfter(query, queryMethod);}
+          break;
+        case TRUNCATE:          // TRUNCATE [TABLE] X
+          queryTable = findTableAfter(query, queryMethod + " TABLE");
+          if(queryTable.equals("N/A")) {queryTable = findTableAfter(query, queryMethod);}
+          break;
+      }
+      return String.format("Cassandra.%s - %s", definitionMethod.toString(), queryTable);
+    }
+    return "Cassandra";
+  }
+
+  private ManipulationMethod getManipulationMethod(String query) {
+    ManipulationMethod retMethod = ManipulationMethod.NOT_FOUND;
+    String upperQuery = query.toUpperCase();
+    for(String method: CASSANDRA_MANIPULATION_METHODS) {
+      if(upperQuery.contains(method)) {
+        retMethod = ManipulationMethod.valueOf(method.replace(' ', '_'));
+        break;
+      }
+    }
+    return retMethod;
+  }
+
+  private DefinitionMethod getDefininitionMethod(String query) {
+    DefinitionMethod retMethod = DefinitionMethod.NOT_FOUND;
+    String upperQuery = query.toUpperCase();
+    for(String method: CASSANDRA_DEFINITION_METHODS) {
+      if(upperQuery.contains(method)) {
+        retMethod = DefinitionMethod.valueOf(method.replace(' ', '_'));
+        break;
+      }
+    }
+    return retMethod;
+  }
+
+  private String findTableAfter(String query, String after) {
+    // Regex to find the first word (containing only alphanumeric, period, or underscore characters)
+    // that occurs after the String after
+    Pattern findTablePattern = Pattern.compile(Pattern.quote(after) + " ([\\w.]+)");
+    Matcher matcher = findTablePattern.matcher(query);
+    if(matcher.find()) {
+      return matcher.group(1);
+    } else {
+      return "N/A";
+    }
+  }
+
+  public static Builder newBuilder() { return new Builder();}
+}

--- a/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/QueryMethodTableSpanName.java
+++ b/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/QueryMethodTableSpanName.java
@@ -23,6 +23,15 @@ import java.util.regex.Pattern;
  */
 public class QueryMethodTableSpanName implements QuerySpanNameProvider {
 
+  public static class Builder implements QuerySpanNameProvider.Builder {
+    @Override
+    public QuerySpanNameProvider build() { return new io.opentracing.contrib.cassandra.QuerySpanNameProvider.QueryMethodTableSpanName();}
+
+  }
+
+  QueryMethodTableSpanName() {
+  }
+
   // Pulled from http://cassandra.apache.org/doc/latest/cql/
   enum ManipulationMethod
   {
@@ -61,15 +70,6 @@ public class QueryMethodTableSpanName implements QuerySpanNameProvider {
       "ALTER MATERIALIZED VIEW",
       "DROP MATERIALIZED VIEW"
   };
-
-  static class Builder implements QuerySpanNameProvider.Builder {
-    @Override
-    public QuerySpanNameProvider build() { return new io.opentracing.contrib.cassandra.QuerySpanNameProvider.QueryMethodTableSpanName();}
-
-  }
-
-  QueryMethodTableSpanName() {
-  }
 
   @Override
   public String querySpanName(String query) {

--- a/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/QueryMethodTableSpanName.java
+++ b/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/QueryMethodTableSpanName.java
@@ -25,7 +25,7 @@ public class QueryMethodTableSpanName implements QuerySpanNameProvider {
 
   public static class Builder implements QuerySpanNameProvider.Builder {
     @Override
-    public QuerySpanNameProvider build() { return new io.opentracing.contrib.cassandra.QuerySpanNameProvider.QueryMethodTableSpanName();}
+    public QuerySpanNameProvider build() { return new QueryMethodTableSpanName();}
 
   }
 

--- a/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/QuerySpanNameProvider.java
+++ b/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/QuerySpanNameProvider.java
@@ -1,0 +1,10 @@
+package io.opentracing.contrib.cassandra.QuerySpanNameProvider;
+
+public interface QuerySpanNameProvider {
+  interface Builder {
+    QuerySpanNameProvider build();
+  }
+
+  String querySpanName(String query);
+
+}

--- a/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/QuerySpanNameProvider.java
+++ b/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/QuerySpanNameProvider.java
@@ -17,7 +17,7 @@ package io.opentracing.contrib.cassandra.QuerySpanNameProvider;
  * @author Jordan J Lopez
  */
 public interface QuerySpanNameProvider {
-  interface Builder {
+  public interface Builder {
     QuerySpanNameProvider build();
   }
 

--- a/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/QuerySpanNameProvider.java
+++ b/src/main/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/QuerySpanNameProvider.java
@@ -1,10 +1,31 @@
+/*
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.cassandra.QuerySpanNameProvider;
 
+/**
+ * @author Jordan J Lopez
+ */
 public interface QuerySpanNameProvider {
   interface Builder {
     QuerySpanNameProvider build();
   }
 
+  /**
+   * Given a Cassandra query, return a name for the span
+   * @param query Cassandra query
+   * @return Name for query's span
+   */
   String querySpanName(String query);
 
 }

--- a/src/main/java/io/opentracing/contrib/cassandra/TracingCluster.java
+++ b/src/main/java/io/opentracing/contrib/cassandra/TracingCluster.java
@@ -46,7 +46,9 @@ public class TracingCluster extends Cluster {
    * {@inheritDoc}
    */
   @Override
-  public Session newSession() {return new TracingSession(super.newSession(), tracer, querySpanNameProvider);}
+  public Session newSession() {
+    return new TracingSession(super.newSession(), tracer, querySpanNameProvider);
+  }
 
   /**
    * {@inheritDoc}

--- a/src/main/java/io/opentracing/contrib/cassandra/TracingCluster.java
+++ b/src/main/java/io/opentracing/contrib/cassandra/TracingCluster.java
@@ -19,6 +19,8 @@ import com.google.common.base.Function;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.opentracing.Tracer;
+import io.opentracing.contrib.cassandra.QuerySpanNameProvider.CustomStringSpanName;
+import io.opentracing.contrib.cassandra.QuerySpanNameProvider.QuerySpanNameProvider;
 
 /**
  * Tracing decorator for {@link Cluster}
@@ -26,19 +28,25 @@ import io.opentracing.Tracer;
 public class TracingCluster extends Cluster {
 
   private final Tracer tracer;
+  private final QuerySpanNameProvider querySpanNameProvider;
 
   public TracingCluster(Initializer initializer, Tracer tracer) {
     super(initializer);
     this.tracer = tracer;
+    this.querySpanNameProvider = CustomStringSpanName.newBuilder().build("execute");
+  }
+
+  public TracingCluster(Initializer initializer, Tracer tracer, QuerySpanNameProvider querySpanNameProvider) {
+    super(initializer);
+    this.tracer = tracer;
+    this.querySpanNameProvider = querySpanNameProvider;
   }
 
   /**
    * {@inheritDoc}
    */
   @Override
-  public Session newSession() {
-    return new TracingSession(super.newSession(), tracer);
-  }
+  public Session newSession() {return new TracingSession(super.newSession(), tracer, querySpanNameProvider);}
 
   /**
    * {@inheritDoc}
@@ -75,7 +83,7 @@ public class TracingCluster extends Cluster {
     return Futures.transform(super.connectAsync(keyspace), new Function<Session, Session>() {
       @Override
       public Session apply(Session session) {
-        return new TracingSession(session, tracer);
+        return new TracingSession(session, tracer, querySpanNameProvider);
       }
     });
   }

--- a/src/test/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/CustomStringSpanNameTest.java
+++ b/src/test/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/CustomStringSpanNameTest.java
@@ -1,0 +1,18 @@
+package io.opentracing.contrib.cassandra.QuerySpanNameProvider;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class CustomStringSpanNameTest {
+  @Test
+  public void customStringSpanNameTest() {
+    QuerySpanNameProvider customStringSpanName = CustomStringSpanName.newBuilder().build();
+    assertEquals("execute", customStringSpanName.querySpanName("SELECT * FROM test.table_name;"));
+
+    customStringSpanName = CustomStringSpanName.newBuilder().build(null);
+    assertEquals("execute", customStringSpanName.querySpanName("SELECT * FROM test.table_name;"));
+
+    customStringSpanName = CustomStringSpanName.newBuilder().build("CUSTOM");
+    assertEquals("CUSTOM", customStringSpanName.querySpanName("SELECT * FROM test.table_name;"));
+  }
+}

--- a/src/test/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/CustomStringSpanNameTest.java
+++ b/src/test/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/CustomStringSpanNameTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.cassandra.QuerySpanNameProvider;
 
 import org.junit.Test;

--- a/src/test/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/FullQuerySpanNameTest.java
+++ b/src/test/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/FullQuerySpanNameTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.cassandra.QuerySpanNameProvider;
 
 import org.junit.Test;

--- a/src/test/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/FullQuerySpanNameTest.java
+++ b/src/test/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/FullQuerySpanNameTest.java
@@ -1,0 +1,14 @@
+package io.opentracing.contrib.cassandra.QuerySpanNameProvider;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class FullQuerySpanNameTest {
+  @Test
+  public void fullQuerySpanNameTest() {
+    QuerySpanNameProvider fullQuerySpanName = FullQuerySpanName.newBuilder().build();
+    assertEquals("SELECT * FROM test.table_name;", fullQuerySpanName.querySpanName("SELECT * FROM test.table_name;"));
+    assertEquals("N/A", fullQuerySpanName.querySpanName(""));
+    assertEquals("N/A", fullQuerySpanName.querySpanName(null));
+  }
+}

--- a/src/test/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/PrefixedFullQuerySpanNameTest.java
+++ b/src/test/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/PrefixedFullQuerySpanNameTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.cassandra.QuerySpanNameProvider;
 
 import org.junit.Test;

--- a/src/test/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/PrefixedFullQuerySpanNameTest.java
+++ b/src/test/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/PrefixedFullQuerySpanNameTest.java
@@ -1,0 +1,31 @@
+package io.opentracing.contrib.cassandra.QuerySpanNameProvider;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PrefixedFullQuerySpanNameTest {
+  @Test
+  public void prefixedFullQuerySpanNameTest() {
+    // Default constructor
+    QuerySpanNameProvider fullQuerySpanName = PrefixedFullQuerySpanName.newBuilder().build();
+    assertEquals("Cassandra: SELECT * FROM test.table_name;", fullQuerySpanName.querySpanName("SELECT * FROM test.table_name;"));
+    assertEquals("Cassandra: N/A", fullQuerySpanName.querySpanName(""));
+    assertEquals("Cassandra: N/A", fullQuerySpanName.querySpanName(null));
+    // Blank prefix
+    fullQuerySpanName = PrefixedFullQuerySpanName.newBuilder().build("");
+    assertEquals("SELECT * FROM test.table_name;", fullQuerySpanName.querySpanName("SELECT * FROM test.table_name;"));
+    assertEquals("N/A", fullQuerySpanName.querySpanName(""));
+    assertEquals("N/A", fullQuerySpanName.querySpanName(null));
+    // Null prefix
+    fullQuerySpanName = PrefixedFullQuerySpanName.newBuilder().build(null);
+    assertEquals("SELECT * FROM test.table_name;", fullQuerySpanName.querySpanName("SELECT * FROM test.table_name;"));
+    assertEquals("N/A", fullQuerySpanName.querySpanName(""));
+    assertEquals("N/A", fullQuerySpanName.querySpanName(null));
+    // Custom prefix
+    fullQuerySpanName = PrefixedFullQuerySpanName.newBuilder().build("CUSTOM");
+    assertEquals("CUSTOM: SELECT * FROM test.table_name;", fullQuerySpanName.querySpanName("SELECT * FROM test.table_name;"));
+    assertEquals("CUSTOM: N/A", fullQuerySpanName.querySpanName(""));
+    assertEquals("CUSTOM: N/A", fullQuerySpanName.querySpanName(null));
+  }
+}

--- a/src/test/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/QueryMethodTableSpanNameTest.java
+++ b/src/test/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/QueryMethodTableSpanNameTest.java
@@ -1,0 +1,105 @@
+package io.opentracing.contrib.cassandra.QuerySpanNameProvider;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class QueryMethodTableSpanNameTest {
+
+  @Test
+  public void manipulationMethodTest() {
+  QuerySpanNameProvider querySpanNameProvider = QueryMethodTableSpanName.newBuilder().build();
+  // SELECT
+  assertEquals("Cassandra.SELECT - test.table_name", querySpanNameProvider.querySpanName("SELECT * FROM test.table_name;"));
+  assertEquals("Cassandra.SELECT - N/A", querySpanNameProvider.querySpanName("SELECT *;"));
+  assertEquals("Cassandra.SELECT - N/A", querySpanNameProvider.querySpanName("SELECT * FROM ;"));
+  // INSERT
+  assertEquals("Cassandra.INSERT - test.table_name", querySpanNameProvider.querySpanName("INSERT INTO test.table_name;"));
+  assertEquals("Cassandra.INSERT - N/A", querySpanNameProvider.querySpanName("INSERT;"));
+  assertEquals("Cassandra.INSERT - N/A", querySpanNameProvider.querySpanName("INSERT INTO ;"));
+  // UPDATE
+  assertEquals("Cassandra.UPDATE - test.table_name", querySpanNameProvider.querySpanName("UPDATE test.table_name;"));
+  assertEquals("Cassandra.UPDATE - N/A", querySpanNameProvider.querySpanName("UPDATE;"));
+  assertEquals("Cassandra.UPDATE - N/A", querySpanNameProvider.querySpanName("UPDATE ;"));
+  // DELETE
+  assertEquals("Cassandra.DELETE - test.table_name", querySpanNameProvider.querySpanName("DELETE * FROM test.table_name;"));
+  assertEquals("Cassandra.DELETE - N/A", querySpanNameProvider.querySpanName("DELETE *;"));
+  assertEquals("Cassandra.DELETE - N/A", querySpanNameProvider.querySpanName("DELETE * FROM ;"));
+  // BATCH
+  assertEquals("Cassandra.BATCH", querySpanNameProvider.querySpanName("BEGIN BATCH;"));
+  assertEquals("Cassandra.BATCH", querySpanNameProvider.querySpanName("APPLY BATCH;"));
+  }
+
+  @Test
+  public void definitionMethodTest() {
+  QuerySpanNameProvider querySpanNameProvider = new QueryMethodTableSpanName().newBuilder().build();
+  // USE
+  assertEquals("Cassandra.USE - test", querySpanNameProvider.querySpanName("USE test;"));
+  assertEquals("Cassandra.USE - N/A", querySpanNameProvider.querySpanName("USE;"));
+  assertEquals("Cassandra.USE - N/A", querySpanNameProvider.querySpanName("USE ;"));
+  // CREATE_KEYSPACE
+  assertEquals("Cassandra.CREATE_KEYSPACE - test", querySpanNameProvider.querySpanName("CREATE KEYSPACE test;"));
+  assertEquals("Cassandra.CREATE_KEYSPACE - test", querySpanNameProvider.querySpanName("CREATE KEYSPACE IF NOT EXISTS test;"));
+  assertEquals("Cassandra.CREATE_KEYSPACE - N/A", querySpanNameProvider.querySpanName("CREATE KEYSPACE"));
+  assertEquals("Cassandra.CREATE_KEYSPACE - N/A", querySpanNameProvider.querySpanName("CREATE KEYSPACE ;"));
+  // ALTER_KEYSPACE
+  assertEquals("Cassandra.ALTER_KEYSPACE - test", querySpanNameProvider.querySpanName("ALTER KEYSPACE test;"));
+  assertEquals("Cassandra.ALTER_KEYSPACE - N/A", querySpanNameProvider.querySpanName("ALTER KEYSPACE;"));
+  assertEquals("Cassandra.ALTER_KEYSPACE - N/A", querySpanNameProvider.querySpanName("ALTER KEYSPACE ;"));
+  // DROP_KEYSPACE
+  assertEquals("Cassandra.DROP_KEYSPACE - test", querySpanNameProvider.querySpanName("DROP KEYSPACE test;"));
+  assertEquals("Cassandra.DROP_KEYSPACE - test", querySpanNameProvider.querySpanName("DROP KEYSPACE IF EXISTS test;"));
+  assertEquals("Cassandra.DROP_KEYSPACE - N/A", querySpanNameProvider.querySpanName("DROP KEYSPACE;"));
+  assertEquals("Cassandra.DROP_KEYSPACE - N/A", querySpanNameProvider.querySpanName("DROP KEYSPACE ;"));
+  // CREATE_TABLE
+  assertEquals("Cassandra.CREATE_TABLE - test.table_name", querySpanNameProvider.querySpanName("CREATE TABLE test.table_name;"));
+  assertEquals("Cassandra.CREATE_TABLE - test.table_name", querySpanNameProvider.querySpanName("CREATE TABLE IF NOT EXISTS test.table_name;"));
+  assertEquals("Cassandra.CREATE_TABLE - N/A", querySpanNameProvider.querySpanName("CREATE TABLE;"));
+  assertEquals("Cassandra.CREATE_TABLE - N/A", querySpanNameProvider.querySpanName("CREATE TABLE ;"));
+  // ALTER_TABLE
+  assertEquals("Cassandra.ALTER_TABLE - test.table_name", querySpanNameProvider.querySpanName("ALTER TABLE test.table_name;"));
+  assertEquals("Cassandra.ALTER_TABLE - N/A", querySpanNameProvider.querySpanName("ALTER TABLE;"));
+  assertEquals("Cassandra.ALTER_TABLE - N/A", querySpanNameProvider.querySpanName("ALTER TABLE ;"));
+  // DROP_TABLE
+  assertEquals("Cassandra.DROP_TABLE - test.table_name", querySpanNameProvider.querySpanName("DROP TABLE test.table_name;"));
+  assertEquals("Cassandra.DROP_TABLE - test.table_name", querySpanNameProvider.querySpanName("DROP TABLE IF EXISTS test.table_name;"));
+  assertEquals("Cassandra.DROP_TABLE - N/A", querySpanNameProvider.querySpanName("DROP TABLE;"));
+  assertEquals("Cassandra.DROP_TABLE - N/A", querySpanNameProvider.querySpanName("DROP TABLE ;"));
+  // TRUNCATE
+  assertEquals("Cassandra.TRUNCATE - test.table_name", querySpanNameProvider.querySpanName("TRUNCATE test.table_name;"));
+  assertEquals("Cassandra.TRUNCATE - test.table_name", querySpanNameProvider.querySpanName("TRUNCATE TABLE test.table_name;"));
+  assertEquals("Cassandra.TRUNCATE - N/A", querySpanNameProvider.querySpanName("TRUNCATE;"));
+  assertEquals("Cassandra.TRUNCATE - N/A", querySpanNameProvider.querySpanName("TRUNCATE ;"));
+  // CREATE_INDEX
+  assertEquals("Cassandra.CREATE_INDEX - test_index", querySpanNameProvider.querySpanName("CREATE INDEX test_index;"));
+  assertEquals("Cassandra.CREATE_INDEX - test_index", querySpanNameProvider.querySpanName("CREATE INDEX IF NOT EXISTS test_index;"));
+  assertEquals("Cassandra.CREATE_INDEX - N/A", querySpanNameProvider.querySpanName("CREATE INDEX;"));
+  assertEquals("Cassandra.CREATE_INDEX - N/A", querySpanNameProvider.querySpanName("CREATE INDEX ;"));
+  // DROP_INDEX
+  assertEquals("Cassandra.DROP_INDEX - test_index", querySpanNameProvider.querySpanName("DROP INDEX test_index;"));
+  assertEquals("Cassandra.DROP_INDEX - test_index", querySpanNameProvider.querySpanName("DROP INDEX IF EXISTS test_index;"));
+  assertEquals("Cassandra.DROP_INDEX - N/A", querySpanNameProvider.querySpanName("DROP INDEX;"));
+  assertEquals("Cassandra.DROP_INDEX - N/A", querySpanNameProvider.querySpanName("DROP INDEX ;"));
+  // CREATE_MATERIALIZED_VIEW
+  assertEquals("Cassandra.CREATE_MATERIALIZED_VIEW - view_name", querySpanNameProvider.querySpanName("CREATE MATERIALIZED VIEW view_name;"));
+  assertEquals("Cassandra.CREATE_MATERIALIZED_VIEW - view_name", querySpanNameProvider.querySpanName("CREATE MATERIALIZED VIEW IF NOT EXISTS view_name;"));
+  assertEquals("Cassandra.CREATE_MATERIALIZED_VIEW - N/A", querySpanNameProvider.querySpanName("CREATE MATERIALIZED VIEW;"));
+  assertEquals("Cassandra.CREATE_MATERIALIZED_VIEW - N/A", querySpanNameProvider.querySpanName("CREATE MATERIALIZED VIEW ;"));
+  // ALTER_MATERIALIZED_VIEW
+  assertEquals("Cassandra.ALTER_MATERIALIZED_VIEW - view_name", querySpanNameProvider.querySpanName("ALTER MATERIALIZED VIEW view_name;"));
+  assertEquals("Cassandra.ALTER_MATERIALIZED_VIEW - N/A", querySpanNameProvider.querySpanName("ALTER MATERIALIZED VIEW;"));
+  assertEquals("Cassandra.ALTER_MATERIALIZED_VIEW - N/A", querySpanNameProvider.querySpanName("ALTER MATERIALIZED VIEW ;"));
+  // DROP_MATERIALIZED_VIEW
+  assertEquals("Cassandra.DROP_MATERIALIZED_VIEW - view_name", querySpanNameProvider.querySpanName("DROP MATERIALIZED VIEW view_name;"));
+  assertEquals("Cassandra.DROP_MATERIALIZED_VIEW - view_name", querySpanNameProvider.querySpanName("DROP MATERIALIZED VIEW IF EXISTS view_name;"));
+  assertEquals("Cassandra.DROP_MATERIALIZED_VIEW - N/A", querySpanNameProvider.querySpanName("DROP MATERIALIZED VIEW;"));
+  assertEquals("Cassandra.DROP_MATERIALIZED_VIEW - N/A", querySpanNameProvider.querySpanName("DROP MATERIALIZED VIEW ;"));
+  }
+
+  @Test
+  public void testInvalaidMethod() {
+  QuerySpanNameProvider querySpanNameProvider = new QueryMethodTableSpanName().newBuilder().build();
+  assertEquals("Cassandra", querySpanNameProvider.querySpanName(""));
+  assertEquals("Cassandra", querySpanNameProvider.querySpanName(null));
+  assertEquals("Cassandra", querySpanNameProvider.querySpanName("INVALID METHOD"));
+  }
+}

--- a/src/test/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/QueryMethodTableSpanNameTest.java
+++ b/src/test/java/io/opentracing/contrib/cassandra/QuerySpanNameProvider/QueryMethodTableSpanNameTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.cassandra.QuerySpanNameProvider;
 
 import org.junit.Test;


### PR DESCRIPTION
This PR establishes an interface for users to create custom span names for their traced queries.