### PR TITLE
Support a wide range of Guava versions

### DIFF
--- a/src/main/java/io/opentracing/contrib/cassandra/TracingCluster.java
+++ b/src/main/java/io/opentracing/contrib/cassandra/TracingCluster.java
@@ -14,9 +14,9 @@
 package io.opentracing.contrib.cassandra;
 
 import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.GuavaCompatibility;
 import com.datastax.driver.core.Session;
 import com.google.common.base.Function;
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.opentracing.Tracer;
 import io.opentracing.contrib.cassandra.nameprovider.CustomStringSpanName;
@@ -106,7 +106,7 @@ public class TracingCluster extends Cluster {
    */
   @Override
   public ListenableFuture<Session> connectAsync(String keyspace) {
-    return Futures.transform(super.connectAsync(keyspace), new Function<Session, Session>() {
+    return GuavaCompatibility.INSTANCE.transform(super.connectAsync(keyspace), new Function<Session, Session>() {
       @Override
       public Session apply(Session session) {
         return new TracingSession(session, tracer, querySpanNameProvider, executorService);

--- a/src/main/java/io/opentracing/contrib/cassandra/TracingSession.java
+++ b/src/main/java/io/opentracing/contrib/cassandra/TracingSession.java
@@ -16,6 +16,7 @@ package io.opentracing.contrib.cassandra;
 import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.CloseFuture;
 import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.GuavaCompatibility;
 import com.datastax.driver.core.Host;
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.RegularStatement;
@@ -24,7 +25,6 @@ import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.Statement;
 import com.google.common.base.Function;
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
@@ -95,7 +95,7 @@ public class TracingSession implements Session {
    */
   @Override
   public ListenableFuture<Session> initAsync() {
-    return Futures.transform(session.initAsync(), new Function<Session, Session>() {
+    return GuavaCompatibility.INSTANCE.transform(session.initAsync(), new Function<Session, Session>() {
       @Override
       public Session apply(Session session) {
         return new TracingSession(session, tracer);


### PR DESCRIPTION
Use `GuavaCompatibility` helper class from `com.datastax.cassandra:cassandra-driver-core` to support a wide range of Guava versions.

Avoid `java-cassandra-driver` preventing consumers from upgrading Guava.

From `com.datastax.driver.core.GuavaCompatibility`:

```
/**
 * A compatibility layer to support a wide range of Guava versions.
 *
 * <p>The driver is compatible with Guava 16.0.1 or higher, but Guava 20 introduced incompatible
 * breaking changes in its API, that could in turn be breaking for legacy driver clients if we
 * simply upgraded our dependency. We don't want to increment our major version "just" for Guava (we
 * have other changes planned).
 *
 * <p>Therefore we depend on Guava 19, which has both the deprecated and the new APIs, and detect
 * the actual version at runtime in order to call the relevant methods.
 *
 * <p>This is a hack, and might not work with subsequent Guava releases; the real fix is to stop
 * exposing Guava in our public API. We'll address that in version 4 of the driver.
 */
```

https://datastax-oss.atlassian.net/browse/JAVA-1928