### PR TITLE
Set scope=provided

### DIFF
--- a/opentracing-cassandra-driver-3/pom.xml
+++ b/opentracing-cassandra-driver-3/pom.xml
@@ -40,6 +40,7 @@
       <groupId>com.datastax.cassandra</groupId>
       <artifactId>cassandra-driver-core</artifactId>
       <version>${cassandra.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/opentracing-cassandra-driver-4/pom.xml
+++ b/opentracing-cassandra-driver-4/pom.xml
@@ -40,6 +40,7 @@
       <groupId>com.datastax.oss</groupId>
       <artifactId>java-driver-core</artifactId>
       <version>${cassandra.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Setting the scope of the target libraries of instrumentation to "provided". It is a guarantee that the integrating codebase will provide these libraries, otherwise the instrumentation plugin would be moot if the codebase does not already have these libraries.