### PR TITLE
Add DB_STATEMENT to PreparedStatements

### DIFF
--- a/opentracing-cassandra-driver-4/src/main/java/io/opentracing/contrib/cassandra4/TracingCqlSession.java
+++ b/opentracing-cassandra-driver-4/src/main/java/io/opentracing/contrib/cassandra4/TracingCqlSession.java
@@ -17,6 +17,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.context.DriverContext;
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.PrepareRequest;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
@@ -55,6 +56,9 @@ public class TracingCqlSession implements CqlSession {
     if (statement instanceof SimpleStatement) {
       SimpleStatement simpleStatement = (SimpleStatement) statement;
       spanBuilder.withTag(Tags.DB_STATEMENT.getKey(), simpleStatement.getQuery());
+    } else if (statement instanceof BoundStatement) {
+      BoundStatement boundStatement = (BoundStatement) statement;
+      spanBuilder.withTag(Tags.DB_STATEMENT.getKey(), boundStatement.getPreparedStatement().getQuery());
     }
 
     final Span span = spanBuilder.start();
@@ -91,6 +95,9 @@ public class TracingCqlSession implements CqlSession {
     if (statement instanceof SimpleStatement) {
       SimpleStatement simpleStatement = (SimpleStatement) statement;
       spanBuilder.withTag(Tags.DB_STATEMENT.getKey(), simpleStatement.getQuery());
+    } else if (statement instanceof BoundStatement) {
+      BoundStatement boundStatement = (BoundStatement) statement;
+      spanBuilder.withTag(Tags.DB_STATEMENT.getKey(), boundStatement.getPreparedStatement().getQuery());
     }
 
     final Span span = spanBuilder.start();

--- a/opentracing-cassandra-driver-4/src/test/java/io/opentracing/contrib/cassandra4/Cassandra4Test.java
+++ b/opentracing-cassandra-driver-4/src/test/java/io/opentracing/contrib/cassandra4/Cassandra4Test.java
@@ -15,6 +15,7 @@ package io.opentracing.contrib.cassandra4;
 
 import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.literal;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import com.datastax.oss.driver.api.core.CqlSession;
@@ -162,6 +163,7 @@ public class Cassandra4Test {
       assertEquals(Tags.SPAN_KIND_CLIENT, mockSpan.tags().get(Tags.SPAN_KIND.getKey()));
       assertEquals(TracingCqlSession.COMPONENT_NAME, mockSpan.tags().get(Tags.COMPONENT.getKey()));
       assertEquals("cassandra", mockSpan.tags().get(Tags.DB_TYPE.getKey()));
+      assertNotNull(mockSpan.tags().get(Tags.DB_STATEMENT.getKey()));
       assertEquals(0, mockSpan.generatedErrors().size());
       String operationName = mockSpan.operationName();
       assertEquals("execute", operationName);


### PR DESCRIPTION
While migrating from opentracing-cassandra-driver-3 to opentracing-cassandra-driver-4 I noticed that `Tags.DB_STATEMENT` was no longer set for PreparedStatements. This patch fix this regression.

I assume this was an oversight an not a deliberate omission as:

 - Capturing PreparedStatement queries seems safer than for SimpleStatement as actual value are not present.
 -  Getting the query seems simple, safe, and cheap.