### PR TITLE
Change ipv4 value to ip address instead of an integer

### DIFF
--- a/opentracing-cassandra-driver-3/src/main/java/io/opentracing/contrib/cassandra/TracingSession.java
+++ b/opentracing-cassandra-driver-3/src/main/java/io/opentracing/contrib/cassandra/TracingSession.java
@@ -391,8 +391,7 @@ public class TracingSession implements Session {
       InetAddress inetAddress = host.getSocketAddress().getAddress();
 
       if (inetAddress instanceof Inet4Address) {
-        byte[] address = inetAddress.getAddress();
-        Tags.PEER_HOST_IPV4.set(span, ByteBuffer.wrap(address).getInt());
+        Tags.PEER_HOST_IPV4.set(span, inetAddress.getHostAddress());
       } else {
         Tags.PEER_HOST_IPV6.set(span, inetAddress.getHostAddress());
       }


### PR DESCRIPTION
Change peer.ipv4 tag value to be the actual ipv4 address instead of the int representation of it.